### PR TITLE
row_offsets

### DIFF
--- a/src/LiquidCrystal_PCF8574.cpp
+++ b/src/LiquidCrystal_PCF8574.cpp
@@ -94,7 +94,13 @@ void LiquidCrystal_PCF8574::home()
 /// Set the cursor to a new position.
 void LiquidCrystal_PCF8574::setCursor(int col, int row)
 {
-  int row_offsets[] = {0x00, 0x40, 0x14, 0x54};
+  int *row_offsets;
+
+  if (this->_lines == 4)
+    row_offsets = new int[4] {0x00, 0x40, 0x10, 0x50};
+  else
+    row_offsets = new int[4] {0x00, 0x40, 0x14, 0x54};
+  
   // Instruction: Set DDRAM address = 0x80
   _send(0x80 | (row_offsets[row] + col));
 } // setCursor()

--- a/src/LiquidCrystal_PCF8574.cpp
+++ b/src/LiquidCrystal_PCF8574.cpp
@@ -33,7 +33,7 @@ LiquidCrystal_PCF8574::LiquidCrystal_PCF8574(int i2cAddr)
 
 void LiquidCrystal_PCF8574::begin(int cols, int lines)
 {
-  (void)cols; // ignored !
+  _cols = cols;
   _lines = lines;
 
   int functionFlags = 0;
@@ -66,6 +66,8 @@ void LiquidCrystal_PCF8574::begin(int cols, int lines)
   display();
   clear();
   leftToRight();
+  
+  _row_offsets = _getRowOffsets();
 } // begin()
 
 
@@ -94,15 +96,8 @@ void LiquidCrystal_PCF8574::home()
 /// Set the cursor to a new position.
 void LiquidCrystal_PCF8574::setCursor(int col, int row)
 {
-  int *row_offsets;
-
-  if (this->_lines == 4)
-    row_offsets = new int[4] {0x00, 0x40, 0x10, 0x50};
-  else
-    row_offsets = new int[4] {0x00, 0x40, 0x14, 0x54};
-  
   // Instruction: Set DDRAM address = 0x80
-  _send(0x80 | (row_offsets[row] + col));
+  _send(0x80 | (_row_offsets[row] + col));
 } // setCursor()
 
 
@@ -283,5 +278,25 @@ void LiquidCrystal_PCF8574::_write2Wire(int halfByte, bool isData, bool enable)
   Wire.write(i2cData);
   Wire.endTransmission();
 } // write2Wire
+
+// Prepare row_offsets
+int* LiquidCrystal_PCF8574::_getRowOffsets()
+{
+  int *row_offsets = new int[this->_lines];
+  
+  if (this->_lines > 0)
+    row_offsets[0] = 0x00;
+  else if (this->_lines > 1)
+    row_offsets[1] = 0x40;
+  else if (this->_lines > 2)
+  {
+    for (int i = 0, j = 2; j < this->_lines; i++, j++)
+    {
+       row_offsets[j] = row_offsets[i] + _cols;
+    }
+  }
+  
+  return row_offsets;
+}
 
 // The End.

--- a/src/LiquidCrystal_PCF8574.h
+++ b/src/LiquidCrystal_PCF8574.h
@@ -74,11 +74,13 @@ private:
   int _lines; ///< number of lines of the display
   int _entrymode; ///<flags from entrymode
   int _displaycontrol; ///<flags from displaycontrol
-
+  int* _row_offsets;
+  
   // low level functions
   void _send(int value, bool isData = false);
   void _sendNibble(int halfByte, bool isData = false);
   void _write2Wire(int halfByte, bool isData, bool enable);
+  int* _getRowOffsets(); 
 };
 
 #endif


### PR DESCRIPTION
Corrected 'row_offsets' for LCDs with 4 lines.

![IMG_0881](https://user-images.githubusercontent.com/16693449/97091544-defe7900-163c-11eb-8744-3e79f1e5ee45.jpg)
