### PR TITLE
Add a PROGMEM variant createCharPgm()

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -29,8 +29,10 @@ autoscroll	KEYWORD2
 noAutoscroll	KEYWORD2
 setBacklight	KEYWORD2
 createChar	KEYWORD2
+createChar_P	KEYWORD2
 setCursor	KEYWORD2
 write	KEYWORD2
+command	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)

--- a/src/LiquidCrystal_PCF8574.cpp
+++ b/src/LiquidCrystal_PCF8574.cpp
@@ -237,6 +237,21 @@ void LiquidCrystal_PCF8574::createChar(int location, byte charmap[])
 } // createChar()
 
 
+#ifdef __AVR__
+// Allows us to fill the first 8 CGRAM locations
+// with custom characters stored in PROGMEM
+void LiquidCrystal_PCF8574::createChar_P(uint8_t location, const byte *charmap) {
+  PGM_P p = reinterpret_cast<PGM_P>(charmap);
+  location &= 0x7; // we only have 8 locations 0-7
+  _send(0x40 | (location << 3));
+  for (int i = 0; i < 8; i++) {
+    byte c = pgm_read_byte(p++);
+    write(c);
+  }
+} // createCharPgm()
+#endif
+
+
 /* The write function is needed for derivation from the Print class. */
 inline size_t LiquidCrystal_PCF8574::write(uint8_t ch)
 {

--- a/src/LiquidCrystal_PCF8574.h
+++ b/src/LiquidCrystal_PCF8574.h
@@ -58,6 +58,12 @@ public:
   void leftToRight();
   void rightToLeft();
   void createChar(int, byte[]);
+#ifdef __AVR__
+  void createChar_P(uint8_t, const byte *);
+  inline void createChar(uint8_t n, const byte *data) {
+    createChar_P(n, data);
+  };
+#endif
 
   // plus functions from LCDAPI:
   void clear(); // same as init()


### PR DESCRIPTION
Allow data for custom characters to be stored in PROGMEM on the AVR platform.
Like the NewLiquidCrystal library, we also offer a variant of createChar
which _assumes_ PROGMEM if the data type is const.
