### PR TITLE
Speed up transfers

### DIFF
--- a/src/LiquidCrystal_PCF8574.h
+++ b/src/LiquidCrystal_PCF8574.h
@@ -98,6 +98,7 @@ private:
   // low level functions
   void _send(uint8_t value, bool isData = false);
   void _sendNibble(uint8_t halfByte, bool isData = false);
+  void _writeNibble(uint8_t halfByte, bool isData);
   void _write2Wire(uint8_t data, bool isData, bool enable);
 
   void init(uint8_t i2cAddr, uint8_t rs, uint8_t rw, uint8_t enable,


### PR DESCRIPTION
An I2C transmission has a significant overhead of ~10+1 I2C clock cycles.
Reducing the number of beginTransmission()/endTransmission() pairs
from twice every nibble to once per _send() hence speeds up transmission
times significantly.

The specified I2C clock rate speed of the PCF8574 chip is 100KHz.
Transmitting a single byte over I2C takes 9 clock ticks or 90us.
Even if the I2C bus is operated beyond the chip's spec in fast mode
at 400 kHz, any additional delays during transmission shorter than this
are unnecessary.

Commands are only executed after the second nibble is transmitted.
The 37us delay after the first nibble is hence unnecessary.

We now omit any additional delays and perform a transmission only once
per _send() command. This reduces the time from 4x(11+9) = 80 cycles to
4x9 + 11 = 47 cycles. Taking the delays into account, this changes the
time per command from 800us + 4*38us = 952us to 470us at the default
100kHz bus speed.